### PR TITLE
Add an empty ./out directory to the repository

### DIFF
--- a/out/.gitignore
+++ b/out/.gitignore
@@ -1,0 +1,6 @@
+# From http://stackoverflow.com/a/932982/992384
+
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This adds the empty ./out directory to the repository. The process doesn't automatically create the ./out directory which leads to the error below unless we manually create the directory:

`{ [Error: ENOENT, no such file or directory 'c:\web\washington-ferries-feed\out\
2015-5-5-8.geojson']
  errno: -4058,
  code: 'ENOENT',
  path: 'c:\\web\\washington-ferries-feed\\out\\2015-5-5-8.geojson',
  syscall: 'open' }`
